### PR TITLE
Test and Api Key

### DIFF
--- a/pensieve/find_images.py
+++ b/pensieve/find_images.py
@@ -2,8 +2,32 @@ import pickle
 import requests
 from PIL import Image
 import urllib
-from .keys import BING_API_KEY
+# from .keys import BING_API_KEY
 from .image import upload_image
+
+
+def get_secret():
+    """Access local store to load secrets."""
+    local = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.sep.join(local.split(os.path.sep)[:3])
+    secret_pth = os.path.join(root, '.ssh', 'bing.json')
+    return secret_pth
+
+
+def load_secret():
+    """Load secrets from a local store.
+
+    Args:
+        server: str defining server
+
+    Returns:
+        dict: storing key: value secrets
+    """
+    pth = get_secret()
+    secret = json.load(open(pth))
+    return secret
+
+BING_API_KEY = load_secret()
 
 
 def search_bing_for_image(query):

--- a/tests/test_data/test_corpus.txt
+++ b/tests/test_data/test_corpus.txt
@@ -1,0 +1,24 @@
+Mr. and Mrs. Dursley, of number four, Privet Drive, were proud to say
+that they were perfectly normal, thank you very much. They were the last
+people you'd expect to be involved in anything strange or mysterious,
+because they just didn't hold with such nonsense.
+
+Mr. Dursley was the director of a firm called Grunnings, which made
+drills. He was a big, beefy man with hardly any neck, although he did
+have a very large mustache. Mrs. Dursley was thin and blonde and had
+nearly twice the usual amount of neck, which came in very useful as she
+spent so much of her time craning over garden fences, spying on the
+neighbors. The Dursleys had a small son called Dudley and in their
+opinion there was no finer boy anywhere.
+
+The Dursleys had everything they wanted, but they also had a secret, and
+their greatest fear was that somebody would discover it. They didn't
+think they could bear it if anyone found out about the Potters. Mrs.
+Potter was Mrs. Dursley's sister, but they hadn't met for several years;
+in fact, Mrs. Dursley pretended she didn't have a sister, because her
+sister and her good-for-nothing husband were as unDursleyish as it was
+possible to be. The Dursleys shuddered to think what the neighbors would
+say if the Potters arrived in the street. The Dursleys knew that the
+Potters had a small son, too, but they had never even seen him. This boy
+was another good reason for keeping the Potters away; they didn't want
+Dudley mixing with a child like that.

--- a/tests/test_pensieve.py
+++ b/tests/test_pensieve.py
@@ -1,0 +1,22 @@
+"""Test jsonschema use with API calls.
+# python -m pytest tests/test_pensieve.py
+"""
+import os
+import pytest
+import pensieve
+
+
+
+@pytest.fixture
+def corpus_dir():
+    cwd = os.getcwd()
+    return os.path.join(cwd, 'tests', 'test_data')
+
+
+def test_corpus(corpus_dir):
+    print('testing', corpus_dir)
+    corpus = pensieve.Corpus(corpus_dir)
+    print(corpus.docs[0].text)
+    print(corpus.paragraphs)
+    assert 3 == len(corpus.paragraphs)
+


### PR DESCRIPTION
- Added alternative method to load keys (avoids failure loading module)
- Added tests dir...currently the test is failing

To run tests:
from /path/to/pensieve

`python -m pytest tests/test_pensieve.py`

Bug me with questions