### PR TITLE
Incorporate image search into pensieve

### DIFF
--- a/harry_potter_book4.json
+++ b/harry_potter_book4.json
@@ -1,0 +1,6647 @@
+[
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "he",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_eyes",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "moment",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "voldemort's_chair",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "what",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "spasm",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "horror",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "pain",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_scar",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "awake",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "swing",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "close",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:10.000Z",
+                    "created": "2017-08-03T01:15:10.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " He closed his eyes tightly and tried to remember what Voldemort had looked like, but it was impossible\u2026All Harry knew was that at the moment when Voldemort's chair had swung around, and he, Harry, had seen what was sitting in it, he had felt a spasm of horror, which had awoken him\u2026or had that been the pain in his scar?",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/3942-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "asleep",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "uncle_vernon",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "dudley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "muggles",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "asleep",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "way",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "uncle_vernon",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "aunt_petunia",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "dudley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry's_only_living_relatives",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "who",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "magic",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "form",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "welcome",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "their_house",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "dry_rot",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry's_long_absences",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "hogwarts",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "last_three_years",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "everyone",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "st._brutus's_secure_center",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "incurably_criminal_boys",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "underage_wizard",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "magic",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "hogwarts",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "anything",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "house",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "anything",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_life",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "wizarding_world",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "very_idea",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_scar",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_worries",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Place",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Place",
+                    "name": "st._brutus's",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Place",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Place",
+                    "name": "hogwarts",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Place",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Place",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "confide",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "awake",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "hurt",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "aunt_petunia",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " Asleep was the way Harry liked the Dursleys best; it wasn't as though they were ever any help to him awake. Uncle Vernon, Aunt Petunia, and Dudley were Harry's only living relatives. They were Muggles who hated and despised magic in any form, which meant that Harry was about as welcome in their house as dry rot. They had explained away Harry's long absences at Hogwarts over the last three years by telling everyone that he went to St. Brutus's Secure Center for Incurably Criminal Boys. They knew perfectly well that, as an underage wizard, Harry wasn't allowed to use magic outside Hogwarts, but they were still apt to blame him for anything that went wrong about the house. Harry had never been able to confide in them or tell them anything about his life in the wizarding world. The very idea of going to them when they awoke, and telling them about his scar hurting him, and about his worries about Voldemort, was laughable.",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/3343-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "dursleys",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "first_place",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "lightning_scar",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_forehead",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "parents",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Place",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Place",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Place",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Place",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Place",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Place",
+                    "name": "voldemort",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "live",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "come",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:11.000Z",
+                    "created": "2017-08-03T01:15:11.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "be",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " And yet it was because of Voldemort that Harry had come to live with the Dursleys in the first place. If it hadn't been for Voldemort, Harry would not have had the lightning scar on his forehead. If it hadn't been for Voldemort, Harry would still have had parents.\u2026",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/89063-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_other_best_friend",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "reaction",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "moment",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "ron's_red_hair",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "face",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "bemused_expression",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "swim",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "wear",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "seem",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "ron_weasley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "ron",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " And so he tried to imagine his other best friend, Ron Weasley's, reaction, and in a moment, Ron's red hair and long-nosed, freckled face seemed to swim before Harry, wearing a bemused expression.",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://www.bing.com/cr?IG=9964F5B7437C4D22BB9A3C1586F552DB&CID=162E5955B7236A591EE55386B67C6BF9&rd=1&h=0UM6DoRSvri9ES4FBGHeXNO7Uu48wptCJLIswPr35s0&v=1&r=https%3a%2f%2fd1hekt5vpuuw9b.cloudfront.net%2fassets%2fc801bfe1c14e25bd13e6aef8a88c2070_bemused-300x300_gallery.jpg&p=DevEx,5008.1",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "misuse_of_muggle_artifacts_office",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "ministry_of_magic",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "weasley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "weasleys",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "mr._weasley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "fully_qualified_wizard",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "who",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "misuse",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "muggle_artifacts_office",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "ministry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "magic",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "particular_expertise",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "matter",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "curses",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "case",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "idea",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "whole_weasley_family",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "few_moments'_pain",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "mrs._weasley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "hermione",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "ron",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "year_old_twin_brothers",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_nerve",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "weasleys",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry's_favorite_family",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "world",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "time",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "ron",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "something",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "quidditch_world_cup",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_visit",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "anxious_inquiries",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_scar",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Place",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Place",
+                    "name": "quidditch_world_cup",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "fuss",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "punctuate",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "invite",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "weasley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "weasley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "hermione",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "fred",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "george",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "ron",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:13.000Z",
+                    "created": "2017-08-03T01:15:13.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "ron",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " Mr. Weasley was a fully qualified wizard who worked in the Misuse of Muggle Artifacts Office at the Ministry of Magic, but he didn't have any particular expertise in the matter of curses, as far as Harry knew. In any case, Harry didn't like the idea of the whole Weasley family knowing that he, Harry, was getting jumpy about a few moments' pain. Mrs. Weasley would fuss worse than Hermione, and Fred and George, Ron's sixteen year old twin brothers, might think Harry was losing his nerve. The Weasleys were Harry's favorite family in the world; he was hoping that they might invite him to stay any time now (Ron had mentioned something about the Quidditch World Cup), and he somehow didn't want his visit punctuated with anxious inquiries about his scar.",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/5132-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "help",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "all_his_school_things",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_bedroom",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "dursleys",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "their_fear",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_powers",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_school_trunk",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "cupboard",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "stairs",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "their_attitude",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "dangerous_murderer",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "godfather",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "couple",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "forget",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "lock",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "dursleys",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " Nevertheless, Sirius had been of some help to Harry, even if he couldn't be with him. It was due to Sirius that Harry now had all his school things in his bedroom with him. The Dursleys had never allowed this before; their general wish of keeping Harry as miserable as possible, coupled with their fear of his powers, had led them to lock his school trunk in the cupboard under the stairs every summer prior to this. But their attitude had changed since they had found out that Harry had a dangerous murderer for a godfather \u2014 for Harry had conveniently forgotten to tell them that Sirius was innocent.",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/2401-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "two_letters",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "privet_drive",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "owls",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "wizards",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "large,_brightly_colored_tropical_birds",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "hedwig",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "flashy_intruders",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "her_water_tray",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "other_hand",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "mind",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "palm_trees",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "white_sand",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "case",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "letters",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "imaging_dementors",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "bright_sunlight",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "south",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sirius's_letters",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "highly_useful_loose_floorboards",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry's_bed",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Place",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Place",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "survive",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "intercept",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "image",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "hedwig",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "south",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "sirius",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " Harry had received two letters from Sirius since he had been back at Privet Drive. Both had been delivered, not by owls (as was usual with wizards), but by large, brightly colored tropical birds. Hedwig had not approved of these flashy intruders; she had been most reluctant to allow them to drink from her water tray before flying off again. Harry, on the other hand, had liked them; they put him in mind of palm trees and white sand, and he hoped that, wherever Sirius was (Sirius never said, in case the letters were intercepted), he was enjoying himself. Somehow, Harry found it hard to imaging dementors surviving for long in bright sunlight, perhaps that was why Sirius had gone South. Sirius's letters, which were now hidden beneath the highly useful loose floorboards under Harry's bed, sounded cheerful, and in both of them he had reminded Harry to call on him if ever Harry needed to. Well, he needed to right now, all right.\u2026",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/10015-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "uncle_vernon",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "aunt_petunia's",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry's_lamp",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "cold_gray_light",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sunrise",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "room",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sun",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_bedroom_walls",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "gold",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sounds",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "movement",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "uncle_vernon",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "aunt_petunia's_room",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_desk",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "crumpled_pieces",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "parchment",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_finished_letter",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "reread",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "clear",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "rise",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " Harry's lamp seemed to grow dimmer as the cold gray light that precedes sunrise slowly crept into the room. Finally, when the sun had risen, when his bedroom walls had turned gold, and when sounds of movement could be heard from Uncle Vernon and Aunt Petunia's room, Harry cleared his desk of crumpled pieces of parchment and reread his finished letter.",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/6606-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "aunt_petunia",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "severe_look",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "dudley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "who",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_own_grapefruit_quarter",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "very_sour_look",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_piggy_little_eyes",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "eye",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "nod",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "finish",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "aunt_petunia",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "dudley",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": " Aunt Petunia gave him a severe look, and then nodded pointedly at Dudley, who had already finished his own grapefruit quarter and was eyeing Harry's with a very sour look in his piggy little eyes.",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/907-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    },
+    {
+        "relation": {
+            "sadness": 0.0,
+            "surprise": 0.0,
+            "joy": 0.0,
+            "anger": 0.0,
+            "disgust": 0.0,
+            "weight": 0.5,
+            "fear": 0.0
+        },
+        "concepts": [
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "quidditch_world_cup",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "department_of_magical_games",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "harry",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "quidditch_world_cup",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "place",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "my_husband",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "prime_tickets",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "his_connections",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "department",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "magical_games",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Thing",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Thing",
+                    "name": "sports",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "manage",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "take",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Activity",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Activity",
+                    "name": "tell",
+                    "label": "",
+                    "iconURL": ""
+                }
+            },
+            {
+                "relation": {
+                    "relation": "Has_Person",
+                    "originType": "OriginUserDefined",
+                    "name": "",
+                    "updated": "2017-08-03T01:15:14.000Z",
+                    "created": "2017-08-03T01:15:14.000Z",
+                    "joy": 0.0,
+                    "imageURL": "",
+                    "anger": 0.0,
+                    "disgust": 0.0,
+                    "weight": 0.5,
+                    "fear": 0.0,
+                    "sadness": 0.0,
+                    "surprise": 0.0,
+                    "iconURL": ""
+                },
+                "node": {
+                    "imageURL": "",
+                    "concept": "Person",
+                    "name": "arthur",
+                    "label": "",
+                    "iconURL": ""
+                }
+            }
+        ],
+        "narrative": {
+            "relation": {
+                "weight": 0.5
+            },
+            "node": {
+                "name": "",
+                "text": "  As Harry might have told you, the final of the Quidditch World Cup takes place this Monday night, and my husband, Arthur, has just managed to get prime tickets through his connections at the Department of Magical Games and Sports. ",
+                "label": "title"
+            }
+        },
+        "node": {
+            "iconURL": "",
+            "updated": "",
+            "created": "",
+            "imageURL": "https://d30y9cdsu7xlg0.cloudfront.net/png/56426-200.png",
+            "name": "",
+            "label": ""
+        },
+        "memory": ""
+    }
+]

--- a/pensieve/json_dump.py
+++ b/pensieve/json_dump.py
@@ -37,7 +37,7 @@ def dump_mem_to_json(mem_dict, save=None):
     for concept_type, concept_items in mem_dict.items():
         if concept_items is None:
             continue
-        if concept_type in ('mood', 'image_url', 'narrative'):
+        if concept_type in ('mood', 'img_url', 'narrative'):
             continue
         for concept_item in concept_items:
             clean_text = concept_item.replace(' ', '_')

--- a/pensieve/pensieve.py
+++ b/pensieve/pensieve.py
@@ -4,7 +4,9 @@ import os
 import textacy
 import string
 from .json_dump import dump_mem_to_json
+from .find_images import search_bing_for_image, search_np_for_image
 import json
+from tqdm import tqdm
 from collections import Counter
 
 print('Loading spaCy...')
@@ -57,7 +59,7 @@ class Corpus(object):
             docs.append(Doc(file_path, i, self))
         return docs
 
-    def find_character_paragraphs(self, char_name, density_cut):
+    def find_character_paragraphs(self, char_name, density_cut=0.8):
         """
         Find paragraphs in the corpus where character is mentioned
         heavily.
@@ -81,7 +83,7 @@ class Corpus(object):
         return char_pars
 
     def gather_corpus_memories(self, char_name, density_cut=0.8,
-                               n_verbs  = 3, save=None):
+                               n_verbs=3, save=None, get_img=False):
         """
         Collects memories from all character paragraphs in the corpus.
 
@@ -96,6 +98,8 @@ class Corpus(object):
             name_cut: like verb_cut, but for people, places, and things
             save: save mem JSON files to this path. If None, files are
                   not saved
+            get_img: get an image url (set to False by default to avoid
+                     using up all the API calls)
 
         Returns:
             memories: list of memories, ready to be put in DB
@@ -103,7 +107,7 @@ class Corpus(object):
         memories = []
         char_pars = self.find_character_paragraphs(char_name, density_cut)
         for par in char_pars:
-            mem_dict = par.gen_mem_dict(char_name, n_verbs)
+            mem_dict = par.gen_mem_dict(char_name, n_verbs, get_img=get_img)
             memories.append(dump_mem_to_json(mem_dict))
         if save is not None:
             if isinstance(char_name, str):
@@ -199,7 +203,7 @@ class Doc(object):
         return char_pars
 
     def gather_doc_memories(self, char_name, density_cut=0.8,
-                            n_verbs = 3, save=None):
+                            n_verbs=3, save=None, get_img=False):
         """
         Collects memories from character paragraphs.
 
@@ -213,20 +217,22 @@ class Doc(object):
             name_cut: like verb_cut, but for people, places, and things
             save: save mem JSON files to this path. If None, files are
                   not saved
+            get_img: get an image url (set to False by default to avoid
+                     using up all the API calls)
 
         Returns:
             memories: list of sanitized memories, ready to be put in DB
         """
         memories = []
         char_pars = self.find_character_paragraphs(char_name, density_cut)
-        for par in char_pars:
-            mem_dict = par.gen_mem_dict(char_name, n_verbs)
+        for par in tqdm(char_pars):
+            mem_dict = par.gen_mem_dict(char_name, n_verbs, get_img=get_img)
             memories.append(dump_mem_to_json(mem_dict))
         if save is not None:
             if isinstance(char_name, str):
                 filebase = char_name.replace(' ', '_').lower().strip()
             else:
-                filebase = '_'.join(char_name)
+                filebase = '_'.join(char_name)+'_book'+str(self.id)
                 filebase = filebase.replace(' ', '_').lower().strip()
             path = os.path.join(save, filebase+'.json')
             with open(path, 'w') as f:
@@ -329,6 +335,25 @@ class Paragraph(object):
             things.append(nch.text.strip())
         return things
 
+    def extract_img_url(self):
+        """
+        Use the keyterms from the text to get a relevant image.
+        The decisions behind this function can be found in the
+        image_search_query notebook
+        """
+        keyterms = textacy.keyterms.textrank(self.spacy_doc)
+        best_keyterm = None
+        for keyterm, rank in keyterms:
+            if keyterm.title() not in self.doc.words['people']:
+                best_keyterm = keyterm
+                break
+        try:
+            urls = search_np_for_image(best_keyterm)
+        except Exception as e:
+            urls = search_bing_for_image(best_keyterm)
+        img_url = urls[0]
+        return img_url
+
     def build_words_dict(self):
         """
         Extract main words from the paragraph.
@@ -356,67 +381,7 @@ class Paragraph(object):
             words_dict['activities'][verb] += 1
         return words_dict
 
-    # def sanitize_places_and_objects(self, freq_cut=100):
-    #     """
-    #     Get a sanitized version of paragraph places and objects.
-    #     Get places that don't appear in the most common doc names, and
-    #     objects that don't appear in the most common doc places.
-
-    #     NOTE: I'm not really sure what this function is actually doing...
-
-    #     Args:
-    #         freq_cut: frequency to define "commonness" within the doc
-
-    #     Returns:
-    #         places: sanitized place names
-    #         objects: sanitized object names
-    #     """
-    #     doc_names = dict(self.doc.words['names'].most_common(freq_cut))
-    #     doc_places = dict(self.doc.words['places'].most_common(freq_cut))
-    #     places = []
-    #     objects = []
-    #     for place in self.words['places']:
-    #         if place not in doc_names:
-    #             places.append(place)
-    #     for obj in self.words['objects']:
-    #         if obj not in doc_places and obj not in places:
-    #             objects.append(obj)
-    #     return places, objects
-
-    # def gen_mem_activity(self, verbs_cut=500):
-    #     """
-    #     Determine the key activities in a paragraph by removing
-    #     verbs commonly used in the doc
-
-    #     Args:
-    #         verbs_cut: frequency of verb in doc to cut on
-
-    #     Returns:
-    #         activities: list of key activity strings
-    #     """
-    #     activities = []
-    #     doc_verbs = dict(self.doc.words['verbs'].most_common(verbs_cut))
-    #     main_verbs = textacy.spacy_utils.get_main_verbs_of_sent(self.spacy_doc)
-    #     for verb in main_verbs:
-    #         if (verb.text in doc_verbs) and (doc_verbs[verb.text] < verbs_cut):
-    #             span = textacy.spacy_utils.get_span_for_verb_auxiliaries(verb)
-    #             complex_verb = self.spacy_doc[span[0]].text
-    #             span_end = 1
-    #             if textacy.spacy_utils.is_negated_verb(verb) is True:
-    #                 complex_verb = complex_verb+' not '
-    #                 span_end = 0
-    #             for a in range(span[0]+1, span[1]+span_end):
-    #                 complex_verb += " "+self.spacy_doc[span[1]].text
-    #             subjects = textacy.spacy_utils.get_subjects_of_verb(verb)
-    #             objects = textacy.spacy_utils.get_objects_of_verb(verb)
-    #             if len(subjects) > 0 and len(objects) > 0:
-    #                 for subject in subjects:
-    #                     for obj in objects:
-    #                         svo = [subject.text, complex_verb, obj.text]
-    #                         activities.append(' '.join(svo))
-    #     return activities
-
-    def gen_mem_dict(self, character, n_verbs):
+    def gen_mem_dict(self, character, n_verbs, get_img=False):
         """
         Determine the most important words of those collected.
 
@@ -424,6 +389,8 @@ class Paragraph(object):
             character: character name string or list of aliases
             verb_cut: frequency of verb in doc to cut on
             name_cut: frequency of name in doc to cut on
+            get_img: get an image url (set to False by default to avoid
+                     using up all the API calls)
 
         Returns:
             culled_output: dictionary of most important people, places,
@@ -438,14 +405,18 @@ class Paragraph(object):
         mem_places = self.extract_places()
         mem_things = self.extract_things()
         mem_activities = self.extract_activities(n_verbs)
+        if get_img:
+            mem_img_url = self.extract_img_url()
+        else:
+            mem_img_url = None
         culled_output = {'people': mem_people,
                          'places': mem_places,
                          'activities': mem_activities,
-                         'things': mem_things}
+                         'things': mem_things,
+                         'img_url': mem_img_url,
+                         'narrative': self.text}
         return culled_output
 
 if __name__ == '__main__':
-    book4 = Doc('/Users/samdixon/repos/cdips_data_science/pensieve/hp_corpus/book4.txt')
-    from pprint import pprint
-    for k, v in book4.words.items():
-        pprint({k: v.most_common(10)})
+    book4 = Doc('/Users/samdixon/repos/cdips_data_science/pensieve/hp_corpus/book4.txt', doc_id=4)
+    print(book4.gather_doc_memories(['Harry', 'Potter'], save='./'))


### PR DESCRIPTION
I've added the image search into the main module. I added a `get_img` flag to `gather_*_memories` that defaults to `False` so we can avoid using up all the Bing/Noun Project API calls when debugging other parts of the code.